### PR TITLE
HCNN-38 changing to use jboss logging from slf4j

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+# Typically *NIX text editors, by default, append '~' to files on saving to make backups
+*~
+
+# Gradle work directory
+.gradle
+
+# Build output directies
+/target
+*/target
+/build
+*/build
+
+# IntelliJ specific files/directories
+out
+.idea
+*.ipr
+*.iws
+*.iml
+atlassian-ide-plugin.xml
+
+# Eclipse specific files/directories
+.classpath
+.project
+.settings
+.metadata
+bin
+
+# NetBeans specific files/directories
+.nbattrs
+
+# Miscellaneous
+*.log
+.clover

--- a/pom.xml
+++ b/pom.xml
@@ -104,8 +104,14 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <version>${jbossLoggingVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-processor</artifactId>
+            <version>${jbossLoggingProcessorVersion}</version>
         </dependency>
         <!-- test-scoped dependencies for common testing dependencies -->
         <dependency>
@@ -114,42 +120,8 @@
             <version>3.8.1</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-            <version>${slf4jVersion}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>${slf4jVersion}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-            <version>99.0-does-not-exist</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging-api</artifactId>
-            <version>99.0-does-not-exist</version>
-            <scope>test</scope>
-        </dependency>
         <!-- / test-scoped dependencies for common testing dependencies -->
     </dependencies>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>${slf4jVersion}</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <distributionManagement>
         <repository>
@@ -165,7 +137,9 @@
     </distributionManagement>
 
     <properties>
-        <slf4jVersion>1.5.8</slf4jVersion>
+        <jbossLoggingVersion>3.0.0.GA</jbossLoggingVersion>
+        <jbossLoggingProcessorVersion>1.0.0.Beta7</jbossLoggingProcessorVersion>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <build>
@@ -173,9 +147,87 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.1.2</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.3.1</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Implementation-Title>${project.name}</Implementation-Title>
+                            <Implementation-Version>${project.version}</Implementation-Version>
+                            <Implementation-Vendor>hibernate.org</Implementation-Vendor>
+                            <Implementation-Vendor-Id>hibernate.org</Implementation-Vendor-Id>
+                            <Implementation-URL>http://hibernate.org</Implementation-URL>
+                        </manifestEntries>
+                        <manifest>
+                            <mainClass>org.hibernate.annotations.common.Version</mainClass>
+                        </manifest>
+
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>build-test-jar</id>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                                    <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                                </manifest>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jboss.maven.plugins</groupId>
+                <artifactId>maven-injection-plugin</artifactId>
+                <version>1.0.2</version>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>bytecode</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <bytecodeInjections>
+                        <bytecodeInjection>
+                            <expression>${project.version}</expression>
+                            <targetMembers>
+                                <methodBodyReturn>
+                                    <className>org.hibernate.annotations.common.Version</className>
+                                    <methodName>getVersionString</methodName>
+                                </methodBodyReturn>
+                            </targetMembers>
+                        </bytecodeInjection>
+                    </bytecodeInjections>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/org/hibernate/annotations/common/AssertionFailure.java
+++ b/src/main/java/org/hibernate/annotations/common/AssertionFailure.java
@@ -22,9 +22,7 @@
  * Boston, MA  02110-1301  USA
  */
 package org.hibernate.annotations.common;
-
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.jboss.logging.Logger;
 
 
 /**
@@ -37,7 +35,7 @@ import org.slf4j.Logger;
  */
 public class AssertionFailure extends RuntimeException {
 
-	private static final Logger log = LoggerFactory.getLogger(AssertionFailure.class);
+	private static final Logger log = Logger.getLogger( AssertionFailure.class );
 
 	private static final String MESSAGE = "an assertion failure occured (this may indicate a bug in Hibernate)";
 

--- a/src/main/java/org/hibernate/annotations/common/Version.java
+++ b/src/main/java/org/hibernate/annotations/common/Version.java
@@ -23,20 +23,26 @@
  */
 package org.hibernate.annotations.common;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.jboss.logging.Logger;
 
 /**
  * @author Emmanuel Bernard
  */
 public class Version {
-	public static final String VERSION = "3.2.1-SNAPSHOT";
-	private static Logger log = LoggerFactory.getLogger( Version.class );
+	private static final Logger log = Logger.getLogger( Version.class );
 
 	static {
-		log.info( "Hibernate Commons Annotations {}", VERSION );
+		log.info( "Hibernate Commons Annotations {" + getVersionString() + "}" );
 	}
+
+    public static String getVersionString(){
+        return "[WORKING]";
+    }
 
 	public static void touch() {
 	}
+
+    public static void main(String[] args) {
+        System.out.println( "Hibernate Commons Annotations {" + getVersionString() + "}" );
+    }
 }


### PR DESCRIPTION
add .gitignore
add maven-source-plugin
add maven-injection-plugin
add maven-jar-plugin

to answer comments in the previous pull request
1. I didn't change copyright in this pull request (I don't know how to config intellij to use that format "2008~${today.year}"??
1. I know that type safe logging message, but this case is so simple, only two classes use this logging api, do we really want to get so complicated? but that's your call :)
2. I want this be fixed since i'm running into trouble with the slf4j 1.5.8 this project introduced into hibernate-core.
   hibernate-core has slf4j 1.6.1 (test scope) and conflict with this project's slf4j 1.5.8 (compile scope) 
