### PR TITLE
Add XClass.getContainingElement()

### DIFF
--- a/src/main/java/org/hibernate/annotations/common/reflection/XClass.java
+++ b/src/main/java/org/hibernate/annotations/common/reflection/XClass.java
@@ -36,6 +36,11 @@ public interface XClass extends XAnnotatedElement {
 	XClass getSuperclass();
 
 	/**
+	 * The containing class or package
+	 */
+	XAnnotatedElement getContainingElement();
+
+	/**
 	 * @see Class#getInterfaces()
 	 */
 	XClass[] getInterfaces();

--- a/src/main/java/org/hibernate/annotations/common/reflection/java/JavaXClass.java
+++ b/src/main/java/org/hibernate/annotations/common/reflection/java/JavaXClass.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 import org.hibernate.annotations.common.reflection.Filter;
 import org.hibernate.annotations.common.reflection.ReflectionUtil;
+import org.hibernate.annotations.common.reflection.XAnnotatedElement;
 import org.hibernate.annotations.common.reflection.XClass;
 import org.hibernate.annotations.common.reflection.XMethod;
 import org.hibernate.annotations.common.reflection.XProperty;
@@ -46,6 +47,22 @@ final class JavaXClass extends JavaXAnnotatedElement implements XClass {
                         getFactory().getTypeEnvironment( toClass() )
 				)
 		);
+	}
+
+	@Override
+	public XAnnotatedElement getContainingElement() {
+		Class<?> enclosingClass = toClass().getEnclosingClass();
+		if (enclosingClass!=null) {
+			return getFactory().toXClass( enclosingClass,
+					CompoundTypeEnvironment.create(
+							getTypeEnvironment(),
+							getFactory().getTypeEnvironment( toClass() )
+					)
+			);
+		}
+		else {
+			return getFactory().toXPackage( toClass().getPackage() );
+		}
 	}
 
 	public XClass[] getInterfaces() {


### PR DESCRIPTION
There's currently no way to get the outer class or package containing an `XClass`.
