### PR TITLE
HCANN-135 Fix build to always product Java 11 compatible binaries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,49 +63,50 @@ compileTestJava {
     targetCompatibility = 11
 }
 
-if ( JavaVersion.current().isCompatibleWith( JavaVersion.VERSION_17 ) ) {
-    // If we run with a JDK17+, we set the toolchain to 17
-    java {
-        toolchain {
-            languageVersion.set(JavaLanguageVersion.of(17))
-        }
-    }
-
-    // And we add a new source set, which contains tests that can run on JDK17+
-    sourceSets {
-        testJava17 {
-            java {
-                srcDirs = ['src/test/java17']
-            }
-        }
-    }
-
-    // For the new source set, we need to configure the source and target version to 17
-    compileTestJava17Java {
-        sourceCompatibility = 17
-        targetCompatibility = 17
-    }
-
-    // The source set gets a custom configuration which extends the normal test implementation config
-    configurations {
-        testJava17Implementation.extendsFrom(testImplementation, testRuntimeOnly)
-        testJava17CompileOnly.extendsFrom(testCompileOnly)
-    }
-
-    // Add the output from src/main/java as dependency
-    dependencies {
-        testJava17Implementation files(sourceSets.main.output.classesDirs) {
-            builtBy compileJava
-        }
-    }
-
-    // We execute the Java 17 tests in a custom test task
-    task testJava17(type: Test) {
-        testClassesDirs = sourceSets.testJava17.output.classesDirs
-        classpath = sourceSets.testJava17.runtimeClasspath
-    }
-
-    testClasses.dependsOn compileTestJava17Java
-    // And run this as part of the check task by default
-    check.dependsOn testJava17
+// Some tests require Java 17
+if ( !JavaVersion.current().isCompatibleWith( JavaVersion.VERSION_17 ) ) {
+    throw new IllegalStateException("Building this project requires JDK 17 (produced binaries will still target Java 11).")
 }
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+}
+
+// We add a new source set, which contains tests that can run on JDK17+
+sourceSets {
+    testJava17 {
+        java {
+            srcDirs = ['src/test/java17']
+        }
+    }
+}
+
+// For the new source set, we need to configure the source and target version to 17
+compileTestJava17Java {
+    sourceCompatibility = 17
+    targetCompatibility = 17
+}
+
+// The source set gets a custom configuration which extends the normal test implementation config
+configurations {
+    testJava17Implementation.extendsFrom(testImplementation, testRuntimeOnly)
+    testJava17CompileOnly.extendsFrom(testCompileOnly)
+}
+
+// Add the output from src/main/java as dependency
+dependencies {
+    testJava17Implementation files(sourceSets.main.output.classesDirs) {
+        builtBy compileJava
+    }
+}
+
+// We execute the Java 17 tests in a custom test task
+task testJava17(type: Test) {
+    testClassesDirs = sourceSets.testJava17.output.classesDirs
+    classpath = sourceSets.testJava17.runtimeClasspath
+}
+
+testClasses.dependsOn compileTestJava17Java
+// And run this as part of the check task by default
+check.dependsOn testJava17

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,17 @@ tasks.compileJava.dependsOn(spotlessApply)
 compileJava.options.encoding = 'UTF-8'
 compileTestJava.options.encoding = 'UTF-8'
 
+// Main binaries use a Java 11 baseline
+compileJava {
+    sourceCompatibility = 11
+    targetCompatibility = 11
+}
+// ... and we want to test against that
+compileTestJava {
+    sourceCompatibility = 11
+    targetCompatibility = 11
+}
+
 if ( JavaVersion.current().isCompatibleWith( JavaVersion.VERSION_17 ) ) {
     // If we run with a JDK17+, we set the toolchain to 17
     java {

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ if ( JavaVersion.current().isCompatibleWith( JavaVersion.VERSION_17 ) ) {
 
     // And we add a new source set, which contains tests that can run on JDK17+
     sourceSets {
-        java17 {
+        testJava17 {
             java {
                 srcDirs = ['src/test/java17']
             }
@@ -70,29 +70,31 @@ if ( JavaVersion.current().isCompatibleWith( JavaVersion.VERSION_17 ) ) {
     }
 
     // For the new source set, we need to configure the source and target version to 17
-    compileJava17Java {
+    compileTestJava17Java {
         sourceCompatibility = 17
         targetCompatibility = 17
     }
 
     // The source set gets a custom configuration which extends the normal test implementation config
     configurations {
-        java17Implementation.extendsFrom(testImplementation)
+        testJava17Implementation.extendsFrom(testImplementation, testRuntimeOnly)
+        testJava17CompileOnly.extendsFrom(testCompileOnly)
     }
 
     // Add the output from src/main/java as dependency
     dependencies {
-        java17Implementation files(sourceSets.main.output.classesDirs) {
+        testJava17Implementation files(sourceSets.main.output.classesDirs) {
             builtBy compileJava
         }
     }
 
     // We execute the Java 17 tests in a custom test task
-    task java17Test(type: Test) {
-        testClassesDirs = sourceSets.java17.output.classesDirs
-        classpath = sourceSets.java17.runtimeClasspath
+    task testJava17(type: Test) {
+        testClassesDirs = sourceSets.testJava17.output.classesDirs
+        classpath = sourceSets.testJava17.runtimeClasspath
     }
 
+    testClasses.dependsOn compileTestJava17Java
     // And run this as part of the check task by default
-    check.dependsOn java17Test
+    check.dependsOn testJava17
 }

--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -57,7 +57,7 @@ pipeline {
 		label 'Release'
 	}
 	tools {
-		jdk 'OpenJDK 11 Latest'
+		jdk 'OpenJDK 17 Latest'
 	}
 	options {
 		buildDiscarder logRotator(daysToKeepStr: '30', numToKeepStr: '10')


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HCANN-135

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-commons-annotations/blob/main/readme.md).

----------------------
