### PR TITLE
Fix broken Export-Package and Private-Package manifest values

### DIFF
--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -209,10 +209,10 @@ class OsgiManifestPackagingInfo {
 
     def applyTo(def manifest) {
         if ( exportPackageInstructions.length > 0 ) {
-            manifest.attributes( 'Export-Package': exportPackageInstructions )
+            manifest.attributes( 'Export-Package': String.join(",", exportPackageInstructions) )
         }
         if ( privatePackageInstructions.length > 0 ) {
-            manifest.attribute( 'Private-Package', privatePackageInstructions )
+            manifest.attributes( 'Private-Package': String.join(",", privatePackageInstructions) )
         }
     }
 }


### PR DESCRIPTION
The value for `Export-Package` in the jar manifest is set to `[Ljava.lang.String;@4bb370b`, since a raw array is pused to the `attributes` method.

This commit transforms the value to a string before calling adding it to the manifest attributes, which will produce a valid value.

Additionally, the logic for `Private-Package` was calling a non existing methos on the manifest object, which only worked, as there are currently no private package instructions. It has been fixed as well.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-commons-annotations/blob/main/readme.md).

----------------------
