### PR TITLE
HCANN-136 Fix broken Export-Package and Private-Package manifest values

### DIFF
--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -209,10 +209,10 @@ class OsgiManifestPackagingInfo {
 
     def applyTo(def manifest) {
         if ( exportPackageInstructions.length > 0 ) {
-            manifest.attributes( 'Export-Package': exportPackageInstructions )
+            manifest.attributes( 'Export-Package': String.join(",", exportPackageInstructions) )
         }
         if ( privatePackageInstructions.length > 0 ) {
-            manifest.attribute( 'Private-Package', privatePackageInstructions )
+            manifest.attributes( 'Private-Package': String.join(",", privatePackageInstructions) )
         }
     }
 }


### PR DESCRIPTION
- supersedes https://github.com/hibernate/hibernate-commons-annotations/pull/29

https://hibernate.atlassian.net/browse/HCANN-136

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-commons-annotations/blob/main/readme.md).

----------------------
